### PR TITLE
Fixes Fygar fire bug

### DIFF
--- a/characters.py
+++ b/characters.py
@@ -290,7 +290,7 @@ class Fygar(Enemy):
             pos = self.pos
             for _ in range(3):
                 pos = mapa.calc_pos(pos, self.dir[self.lastdir], traverse=False)
-                if pos not in self.fire:
+                if pos not in self.fire and not pos == self.pos:  # Make sure we don't fire on ourselves:
                     self.fire.append(pos)
                 else:
                     break

--- a/characters.py
+++ b/characters.py
@@ -290,7 +290,7 @@ class Fygar(Enemy):
             pos = self.pos
             for _ in range(3):
                 pos = mapa.calc_pos(pos, self.dir[self.lastdir], traverse=False)
-                if pos not in self.fire and not pos == self.pos:  # Make sure we don't fire on ourselves:
+                if pos not in self.fire and pos != self.pos:  # Make sure we don't fire on ourselves:
                     self.fire.append(pos)
                 else:
                     break


### PR DESCRIPTION
Makes sure Fygar can't burn himself, therefore not reporting conflicting data to the client, as it would receive the same position for Fygar and the fire.