### PR TITLE
Fix a bug where the vertical caves could spawn open

### DIFF
--- a/mapa.py
+++ b/mapa.py
@@ -63,7 +63,7 @@ class Map:
                 else:
                     # vertical
                     column = random.randrange(0, self.hor_tiles)
-                    offset = random.randrange(0, self.ver_tiles - MIN_CORRIDOR_LEN)
+                    offset = random.randrange(3, self.ver_tiles - MIN_CORRIDOR_LEN)
                     for y in range(MIN_CORRIDOR_LEN):
                         self.map[column][offset + y] = Tiles.PASSAGE
                     self._enemies_spawn.append((column, offset))


### PR DESCRIPTION
This pr fixes a bug where the vertical caves could spawn open, causing the enemies to run away at the level start